### PR TITLE
fix: wait for leaflet lib to be loaded

### DIFF
--- a/src/djangocms_leaflet/templates/djangocms_leaflet/map.html
+++ b/src/djangocms_leaflet/templates/djangocms_leaflet/map.html
@@ -25,14 +25,13 @@
 
 {% addtoblock "js" strip %}
 <script>
-{# Replacement for jquery’s $(function() {}) #}
-{# https://stackoverflow.com/questions/799981/document-ready-equivalent-without-jquery #}
 function ready(fn) {
-  if (document.readyState !== 'loading') {
-    fn();
-    return;
-  }
-  document.addEventListener('DOMContentLoaded', fn);
+    // waits for the document to be fully loaded if leaflet is not available yet
+    if (window.L) {
+        fn();
+    } else {
+        window.addEventListener('load', fn);
+    }
 }
 </script>
 {% endaddtoblock %}


### PR DESCRIPTION
This PR will show maps immediately after they are added to a CMS document. (Tested with current django CMS develop-4)